### PR TITLE
Support dynamics tags

### DIFF
--- a/Tag/Tag.php
+++ b/Tag/Tag.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace AirSlate\Datadog\Tag;
+
+
+/**
+ * Class Tag
+ *
+ * @package AirSlate\Datadog\Tag
+ */
+class Tag
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * Tag constructor.
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    public function __construct(string $key, $value)
+    {
+        $this->key = $key;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,15 @@ datadog:
       NON_LOCAL_TRAFFIC: "true"
 ```
 
+## Add Default tags
+
+```php
+    $this->app->bind('datadog.company.tag', function() {
+        return new Tag('company', 'airslate');
+    });
+    $this->app->tag('datadog.company.tag', DatadogProvider::DATADOG_TAG);
+```
+
 ## Datadog metrics
 
 ### airslate.eventbus.receive(time)


### PR DESCRIPTION
Added the ability to add tags through the laravel service provider. 
Also refactored Datadog instance registration. 

## Usage

```php
	$this->app->bind('datadog.company.tag', function() {
		return new Tag('company', 'airslate');
	})
	$this->app->tag('datadog.company.tag', DatadogProvider::DATADOG_TAG);
```