### PR TITLE
created event configuration

### DIFF
--- a/config/datadog.php
+++ b/config/datadog.php
@@ -7,4 +7,35 @@ return [
     'statsd_port' => env('STATSD_PORT', 8125),
     'statsd_env' => env('APP_ENV'),
     'is_send_increment_metric_with_timing_metric' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Datadog Events Configuration
+    |--------------------------------------------------------------------------
+    | Sends message to datadog metric when some event calls. Just remove FQN to disable event listening.
+    */
+    'events' => [
+        'defaultEvents' => [
+            AirSlate\EventBusHelper\Events\ProcessedEvent::class,
+            AirSlate\EventBusHelper\Events\RejectedEvent::class,
+            AirSlate\EventBusHelper\Events\RetryEvent::class,
+            AirSlate\EventBusHelper\Events\SendEvent::class,
+            AirSlate\EventBusHelper\Events\SendToQueueEvent::class,
+            Illuminate\Queue\Events\JobProcessing::class,
+            Illuminate\Queue\Events\JobProcessed::class,
+            Illuminate\Queue\Events\JobExceptionOccurred::class,
+            Illuminate\Queue\Events\JobFailed::class,
+            Illuminate\Cache\Events\CacheHit::class,
+            Illuminate\Cache\Events\CacheMissed::class,
+            Illuminate\Cache\Events\KeyForgotten::class,
+            Illuminate\Cache\Events\KeyWritten::class,
+            Illuminate\Database\Events\QueryExecuted::class,
+            Illuminate\Database\Events\TransactionBeginning::class,
+            Illuminate\Database\Events\TransactionCommitted::class,
+            Illuminate\Database\Events\TransactionRolledBack::class,
+        ],
+        'customEvents' => [
+            //Your custom events FQN
+        ]
+    ]
 ];

--- a/config/datadog.php
+++ b/config/datadog.php
@@ -37,6 +37,6 @@ return [
         'customEvents' => [
             //Your custom events FQN
         ]
-    ]
+    ],
     'global_tags' => [],
 ];

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,16 @@ datadog:
     $this->app->tag('datadog.company.tag', DatadogProvider::DATADOG_TAG);
 ```
 
+## Turn on\off default events
+
+Remove FQN event name class from config `datadog.php` to switch off event, or add it back to switch on.
+
+## Add custom events
+
+You can add your own events which name and custom tags. Just do 2 steps.
+1. Create simple event and implement it of `AirSlate\Datadog\Events\DatadogEventInterface`.
+2. Add your FQN of custom event to config datadog.php in `customEvents` array.
+
 ## Statsd metrics
 
 ### airslate.eventbus.receive(time)

--- a/src/Events/DatadogEventInterface.php
+++ b/src/Events/DatadogEventInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AirSlate\Datadog\Events;
+
+/**
+ * Interface DatadogEventInterface
+ */
+interface DatadogEventInterface
+{
+    /**
+     * Event category like db/job/cache etc...
+     * @return string
+     */
+    public function getEventCategory(): string;
+
+
+    /**
+     * Event name may be something lke transaction/query/item etc...
+     * @return string
+     */
+    public function getEventName(): string;
+
+    /**
+     * For example: ['tagNeme1' => 'tagValue1', 'tagName2' => 'tagValue2']
+     * @return array
+     */
+    public function getTags(): array;
+}

--- a/src/Listeners/EventBusListener.php
+++ b/src/Listeners/EventBusListener.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace AirSlate\Datadog\Listeners;
 
+use AirSlate\Datadog\Events\DatadogEventInterface;
+use AirSlate\Datadog\Events\DatadogEventJobInterface;
 use AirSlate\Datadog\Services\Datadog;
 use AirSlate\Datadog\Services\QueueJobMeter;
 use AirSlate\EventBusHelper\Events\ProcessedEvent;
@@ -30,7 +32,7 @@ use Laravel\Horizon\Events\JobFailed;
  * @property Datadog $datadog
  * @property QueueJobMeter $meter
  * @property string $namespace
- * @property array $allowEvents
+ * @property array $defaultEvents
  * @property array $customEvents
  */
 class EventBusListener
@@ -53,7 +55,7 @@ class EventBusListener
     /**
      * @var array
      */
-    protected $allowEvents;
+    protected $defaultEvents;
 
     /**
      * @var array
@@ -73,7 +75,7 @@ class EventBusListener
         $this->datadog = $datadog;
         $this->meter = $meter;
         $this->namespace = $namespace;
-        $this->allowEvents = $events['defaultEvents'];
+        $this->defaultEvents = $events['defaultEvents'];
         $this->customEvents = $events['customEvents'];
     }
 
@@ -83,90 +85,95 @@ class EventBusListener
      */
     public function handle($event): void
     {
-        if ($event instanceof ProcessedEvent && in_array(ProcessedEvent::class, $this->allowEvents)) {
+        if ($event instanceof ProcessedEvent && in_array(ProcessedEvent::class, $this->defaultEvents)) {
             $this->datadog->timing("{$this->namespace}.eventbus.receive", $this->getDuration($event), 1, [
                 'key' => $event->getRoutingKey(),
                 'queue' => $event->getQueueName(),
                 'status' => 'processed',
             ]);
-        } elseif ($event instanceof RejectedEvent && in_array(RejectedEvent::class, $this->allowEvents)) {
+        } elseif ($event instanceof RejectedEvent && in_array(RejectedEvent::class, $this->defaultEvents)) {
             $this->datadog->timing("{$this->namespace}.eventbus.receive", $this->getDuration($event), 1, [
                 'key' => $event->getRoutingKey(),
                 'queue' => $event->getQueueName(),
                 'status' => 'rejected',
             ]);
-        } elseif ($event instanceof RetryEvent && in_array(RetryEvent::class, $this->allowEvents)) {
+        } elseif ($event instanceof RetryEvent && in_array(RetryEvent::class, $this->defaultEvents)) {
             $this->datadog->timing("{$this->namespace}.eventbus.receive", $this->getDuration($event), 1, [
                 'key' => $event->getRoutingKey(),
                 'queue' => $event->getQueueName(),
                 'status' => 'retried',
             ]);
-        } elseif ($event instanceof SendEvent && in_array(SendEvent::class, $this->allowEvents)) {
+        } elseif ($event instanceof SendEvent && in_array(SendEvent::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.eventbus.send", 1, [
                 'key' => $event->getRoutingKey(),
             ]);
-        } elseif ($event instanceof SendToQueueEvent && in_array(SendToQueueEvent::class, $this->allowEvents)) {
+        } elseif ($event instanceof SendToQueueEvent && in_array(SendToQueueEvent::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.eventbus.sendtoqueue", 1, [
                 'queue' => $event->getQueueName(),
             ]);
-        } elseif ($event instanceof JobProcessing && in_array(JobProcessing::class, $this->allowEvents)) {
+        } elseif ($event instanceof JobProcessing && in_array(JobProcessing::class, $this->defaultEvents)) {
             $this->meter->start($event->job);
-        } elseif ($event instanceof JobProcessed && in_array(JobProcessed::class, $this->allowEvents)) {
+        } elseif ($event instanceof JobProcessed && in_array(JobProcessed::class, $this->defaultEvents)) {
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, [
                 'status' => 'processed',
                 'queue' => $event->job->getQueue(),
                 'task' => $this->getClassShortName($event->job->resolveName())
             ]);
         } elseif ($event instanceof JobExceptionOccurred
-            && in_array(JobExceptionOccurred::class, $this->allowEvents)) {
+            && in_array(JobExceptionOccurred::class, $this->defaultEvents)) {
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, [
                 'status' => 'exceptionOccurred',
                 'queue' => $event->job->getQueue(),
                 'task' => $this->getClassShortName($event->job->resolveName()),
                 'exception' => $this->getClassShortName(get_class($event->exception))
             ]);
-        } elseif ($event instanceof JobFailed && in_array(JobFailed::class, $this->allowEvents)) {
+        } elseif ($event instanceof JobFailed && in_array(JobFailed::class, $this->defaultEvents)) {
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, [
                 'status' => 'failed',
                 'queue' => $event->job->getQueue(),
                 'task' => $this->getClassShortName($event->job->resolveName()),
                 'exception' => $this->getClassShortName(get_class($event->exception))
             ]);
-        } elseif ($event instanceof CacheHit && in_array(CacheHit::class, $this->allowEvents)) {
+        } elseif ($event instanceof CacheHit && in_array(CacheHit::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'hit',
             ]);
-        } elseif ($event instanceof CacheMissed && in_array(CacheMissed::class, $this->allowEvents)) {
+        } elseif ($event instanceof CacheMissed && in_array(CacheMissed::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'miss',
             ]);
-        } elseif ($event instanceof KeyForgotten && in_array(KeyForgotten::class, $this->allowEvents)) {
+        } elseif ($event instanceof KeyForgotten && in_array(KeyForgotten::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'del',
             ]);
-        } elseif ($event instanceof KeyWritten && in_array(KeyWritten::class, $this->allowEvents)) {
+        } elseif ($event instanceof KeyWritten && in_array(KeyWritten::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'put',
             ]);
-        } elseif ($event instanceof QueryExecuted && in_array(QueryExecuted::class, $this->allowEvents)) {
+        } elseif ($event instanceof QueryExecuted && in_array(QueryExecuted::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.db.query", 1, [
                 'status' => 'executed',
             ]);
         } elseif ($event instanceof TransactionBeginning
-            && in_array(TransactionBeginning::class, $this->allowEvents)) {
+            && in_array(TransactionBeginning::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'begin',
             ]);
         } elseif ($event instanceof TransactionCommitted
-            && in_array(TransactionCommitted::class, $this->allowEvents)) {
+            && in_array(TransactionCommitted::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'commit',
             ]);
         } elseif ($event instanceof TransactionRolledBack
-            && in_array(TransactionRolledBack::class, $this->allowEvents)) {
+            && in_array(TransactionRolledBack::class, $this->defaultEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'rollback',
             ]);
+        }
+
+        // Custom events
+        if ($event instanceof DatadogEventInterface) {
+            $this->datadog->increment("{$this->namespace}.{$event->getEventCategory()},{$event->getEventName()}", 1, $event->getTags());
         }
     }
 

--- a/src/Listeners/EventBusListener.php
+++ b/src/Listeners/EventBusListener.php
@@ -173,7 +173,8 @@ class EventBusListener
 
         // Custom events
         if ($event instanceof DatadogEventInterface) {
-            $this->datadog->increment("{$this->namespace}.{$event->getEventCategory()},{$event->getEventName()}", 1, $event->getTags());
+            $stats = "{$this->namespace}.{$event->getEventCategory()},{$event->getEventName()}";
+            $this->datadog->increment($stats, 1, $event->getTags());
         }
     }
 

--- a/src/Listeners/EventBusListener.php
+++ b/src/Listeners/EventBusListener.php
@@ -137,7 +137,6 @@ class EventBusListener
             ];
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, $tags);
             $this->datadog->gauge("{$this->namespace}.queue.db.queries", $this->queryCounter->getCount(), 1, $tags);
-            ]);
         } elseif ($event instanceof JobExceptionOccurred
             && in_array(JobExceptionOccurred::class, $this->defaultEvents)) {
             $tags = [
@@ -197,7 +196,7 @@ class EventBusListener
 
         // Custom events
         if ($event instanceof DatadogEventInterface) {
-            $stats = "{$this->namespace}.{$event->getEventCategory()},{$event->getEventName()}";
+            $stats = "{$this->namespace}.{$event->getEventCategory()}.{$event->getEventName()}";
             $this->datadog->increment($stats, 1, $event->getTags());
         }
     }

--- a/src/Listeners/EventBusListener.php
+++ b/src/Listeners/EventBusListener.php
@@ -117,7 +117,8 @@ class EventBusListener
                 'queue' => $event->job->getQueue(),
                 'task' => $this->getClassShortName($event->job->resolveName())
             ]);
-        } elseif ($event instanceof JobExceptionOccurred && in_array(JobExceptionOccurred::class, $this->allowEvents)) {
+        } elseif ($event instanceof JobExceptionOccurred
+            && in_array(JobExceptionOccurred::class, $this->allowEvents)) {
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, [
                 'status' => 'exceptionOccurred',
                 'queue' => $event->job->getQueue(),
@@ -151,15 +152,18 @@ class EventBusListener
             $this->datadog->increment("{$this->namespace}.db.query", 1, [
                 'status' => 'executed',
             ]);
-        } elseif ($event instanceof TransactionBeginning && in_array(TransactionBeginning::class, $this->allowEvents)) {
+        } elseif ($event instanceof TransactionBeginning
+            && in_array(TransactionBeginning::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'begin',
             ]);
-        } elseif ($event instanceof TransactionCommitted && in_array(TransactionCommitted::class, $this->allowEvents)) {
+        } elseif ($event instanceof TransactionCommitted
+            && in_array(TransactionCommitted::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'commit',
             ]);
-        } elseif ($event instanceof TransactionRolledBack && in_array(TransactionRolledBack::class, $this->allowEvents)) {
+        } elseif ($event instanceof TransactionRolledBack
+            && in_array(TransactionRolledBack::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'rollback',
             ]);

--- a/src/Listeners/EventBusListener.php
+++ b/src/Listeners/EventBusListener.php
@@ -5,11 +5,33 @@ namespace AirSlate\Datadog\Listeners;
 
 use AirSlate\Datadog\Services\Datadog;
 use AirSlate\Datadog\Services\QueueJobMeter;
+use AirSlate\EventBusHelper\Events\ProcessedEvent;
+use AirSlate\EventBusHelper\Events\SendToQueueEvent;
+use AirSlate\EventBusHelper\Events\SendEvent;
+use AirSlate\EventBusHelper\Events\RetryEvent;
+use AirSlate\EventBusHelper\Events\RejectedEvent;
+use Illuminate\Cache\Events\CacheHit;
+use Illuminate\Cache\Events\CacheMissed;
+use Illuminate\Cache\Events\KeyForgotten;
+use Illuminate\Cache\Events\KeyWritten;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Database\Events\TransactionBeginning;
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionRolledBack;
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Laravel\Horizon\Events\JobFailed;
 
 /**
  * Class EventBusListener
  *
  * @package AirSlate\Datadog\Listenres
+ * @property Datadog $datadog
+ * @property QueueJobMeter $meter
+ * @property string $namespace
+ * @property array $allowEvents
+ * @property array $customEvents
  */
 class EventBusListener
 {
@@ -29,17 +51,30 @@ class EventBusListener
     protected $namespace;
 
     /**
+     * @var array
+     */
+    protected $allowEvents;
+
+    /**
+     * @var array
+     */
+    protected $customEvents;
+
+    /**
      * EventBusListener constructor.
      *
      * @param Datadog $datadog
      * @param QueueJobMeter $meter
      * @param string $namespace
+     * @param array $events
      */
-    public function __construct(Datadog $datadog, QueueJobMeter $meter, string $namespace)
+    public function __construct(Datadog $datadog, QueueJobMeter $meter, string $namespace, array $events)
     {
         $this->datadog = $datadog;
         $this->meter = $meter;
         $this->namespace = $namespace;
+        $this->allowEvents = $events['defaultEvents'];
+        $this->customEvents = $events['customEvents'];
     }
 
     /**
@@ -48,83 +83,83 @@ class EventBusListener
      */
     public function handle($event): void
     {
-        if ($event instanceof \AirSlate\EventBusHelper\Events\ProcessedEvent) {
+        if ($event instanceof ProcessedEvent && in_array(ProcessedEvent::class, $this->allowEvents)) {
             $this->datadog->timing("{$this->namespace}.eventbus.receive", $this->getDuration($event), 1, [
                 'key' => $event->getRoutingKey(),
                 'queue' => $event->getQueueName(),
                 'status' => 'processed',
             ]);
-        } elseif ($event instanceof \AirSlate\EventBusHelper\Events\RejectedEvent) {
+        } elseif ($event instanceof RejectedEvent && in_array(RejectedEvent::class, $this->allowEvents)) {
             $this->datadog->timing("{$this->namespace}.eventbus.receive", $this->getDuration($event), 1, [
                 'key' => $event->getRoutingKey(),
                 'queue' => $event->getQueueName(),
                 'status' => 'rejected',
             ]);
-        } elseif ($event instanceof \AirSlate\EventBusHelper\Events\RetryEvent) {
+        } elseif ($event instanceof RetryEvent && in_array(RetryEvent::class, $this->allowEvents)) {
             $this->datadog->timing("{$this->namespace}.eventbus.receive", $this->getDuration($event), 1, [
                 'key' => $event->getRoutingKey(),
                 'queue' => $event->getQueueName(),
                 'status' => 'retried',
             ]);
-        } elseif ($event instanceof \AirSlate\EventBusHelper\Events\SendEvent) {
+        } elseif ($event instanceof SendEvent && in_array(SendEvent::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.eventbus.send", 1, [
                 'key' => $event->getRoutingKey(),
             ]);
-        } elseif ($event instanceof \AirSlate\EventBusHelper\Events\SendToQueueEvent) {
+        } elseif ($event instanceof SendToQueueEvent && in_array(SendToQueueEvent::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.eventbus.sendtoqueue", 1, [
                 'queue' => $event->getQueueName(),
             ]);
-        } elseif ($event instanceof \Illuminate\Queue\Events\JobProcessing) {
+        } elseif ($event instanceof JobProcessing && in_array(JobProcessing::class, $this->allowEvents)) {
             $this->meter->start($event->job);
-        } elseif ($event instanceof \Illuminate\Queue\Events\JobProcessed) {
+        } elseif ($event instanceof JobProcessed && in_array(JobProcessed::class, $this->allowEvents)) {
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, [
                 'status' => 'processed',
                 'queue' => $event->job->getQueue(),
                 'task' => $this->getClassShortName($event->job->resolveName())
             ]);
-        } elseif ($event instanceof \Illuminate\Queue\Events\JobExceptionOccurred) {
+        } elseif ($event instanceof JobExceptionOccurred && in_array(JobExceptionOccurred::class, $this->allowEvents)) {
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, [
                 'status' => 'exceptionOccurred',
                 'queue' => $event->job->getQueue(),
                 'task' => $this->getClassShortName($event->job->resolveName()),
                 'exception' => $this->getClassShortName(get_class($event->exception))
             ]);
-        } elseif ($event instanceof \Illuminate\Queue\Events\JobFailed) {
+        } elseif ($event instanceof JobFailed && in_array(JobFailed::class, $this->allowEvents)) {
             $this->datadog->timing("{$this->namespace}.queue.job", $this->meter->stop($event->job), 1, [
                 'status' => 'failed',
                 'queue' => $event->job->getQueue(),
                 'task' => $this->getClassShortName($event->job->resolveName()),
                 'exception' => $this->getClassShortName(get_class($event->exception))
             ]);
-        } elseif ($event instanceof \Illuminate\Cache\Events\CacheHit) {
+        } elseif ($event instanceof CacheHit && in_array(CacheHit::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'hit',
             ]);
-        } elseif ($event instanceof \Illuminate\Cache\Events\CacheMissed) {
+        } elseif ($event instanceof CacheMissed && in_array(CacheMissed::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'miss',
             ]);
-        } elseif ($event instanceof \Illuminate\Cache\Events\KeyForgotten) {
+        } elseif ($event instanceof KeyForgotten && in_array(KeyForgotten::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'del',
             ]);
-        } elseif ($event instanceof \Illuminate\Cache\Events\KeyWritten) {
+        } elseif ($event instanceof KeyWritten && in_array(KeyWritten::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.cache.item", 1, [
                 'status' => 'put',
             ]);
-        } elseif ($event instanceof \Illuminate\Database\Events\QueryExecuted) {
+        } elseif ($event instanceof QueryExecuted && in_array(QueryExecuted::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.db.query", 1, [
                 'status' => 'executed',
             ]);
-        } elseif ($event instanceof \Illuminate\Database\Events\TransactionBeginning) {
+        } elseif ($event instanceof TransactionBeginning && in_array(TransactionBeginning::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'begin',
             ]);
-        } elseif ($event instanceof \Illuminate\Database\Events\TransactionCommitted) {
+        } elseif ($event instanceof TransactionCommitted && in_array(TransactionCommitted::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'commit',
             ]);
-        } elseif ($event instanceof \Illuminate\Database\Events\TransactionRolledBack) {
+        } elseif ($event instanceof TransactionRolledBack && in_array(TransactionRolledBack::class, $this->allowEvents)) {
             $this->datadog->increment("{$this->namespace}.db.transaction", 1, [
                 'status' => 'rollback',
             ]);

--- a/src/ServiceProviders/EventServiceProvider.php
+++ b/src/ServiceProviders/EventServiceProvider.php
@@ -27,6 +27,10 @@ class EventServiceProvider extends ServiceProvider
         /** @var Dispatcher $dispatcher */
         $dispatcher = $this->app->get(Dispatcher::class);
 
-        $dispatcher->listen($this->app->get('config')->get('datadog.events'), EventBusListener::class);
+        $eventClasses = array_merge(
+            $this->app->get('config')->get('datadog.events.defaultEvents'),
+            $this->app->get('config')->get('datadog.events.customEvents')
+        );
+        $dispatcher->listen($eventClasses, EventBusListener::class);
     }
 }

--- a/src/ServiceProviders/EventServiceProvider.php
+++ b/src/ServiceProviders/EventServiceProvider.php
@@ -17,30 +17,16 @@ class EventServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->when(EventBusListener::class)
-                  ->needs('$namespace')
-                  ->give($this->app->get('config')->get('datadog.application_namespace', 'unknown'));
+            ->needs('$namespace')
+            ->give($this->app->get('config')->get('datadog.application_namespace', 'unknown'));
+
+        $this->app->when(EventBusListener::class)
+            ->needs('$events')
+            ->give($this->app->get('config')->get('datadog.events'));
 
         /** @var Dispatcher $dispatcher */
         $dispatcher = $this->app->get(Dispatcher::class);
 
-        $dispatcher->listen([
-            'AirSlate\EventBusHelper\Events\ProcessedEvent',
-            'AirSlate\EventBusHelper\Events\RejectedEvent',
-            'AirSlate\EventBusHelper\Events\RetriedEvent',
-            'AirSlate\EventBusHelper\Events\SendEvent',
-            'AirSlate\EventBusHelper\Events\SendToQueueEvent',
-            'Illuminate\Queue\Events\JobProcessing',
-            'Illuminate\Queue\Events\JobProcessed',
-            'Illuminate\Queue\Events\JobExceptionOccurred',
-            'Illuminate\Queue\Events\JobFailed',
-            'Illuminate\Cache\Events\CacheHit',
-            'Illuminate\Cache\Events\CacheMissed',
-            'Illuminate\Cache\Events\KeyForgotten',
-            'Illuminate\Cache\Events\KeyWritten',
-            'Illuminate\Database\Events\QueryExecuted',
-            'Illuminate\Database\Events\TransactionBeginning',
-            'Illuminate\Database\Events\TransactionCommitted',
-            'Illuminate\Database\Events\TransactionRolledBack',
-        ], EventBusListener::class);
+        $dispatcher->listen($this->app->get('config')->get('datadog.events'), EventBusListener::class);
     }
 }


### PR DESCRIPTION
Ідея була в тому щоб  мати змогу вимикати сендери метрик які не потрібні тому як була ситуація коли бібліотека значно сповільнювала запис в редіс через івенти кешу в лісенері. Також щоб мати змогу переоприділяти стандартні класи івентів зашиті в бібліотеці та могти використовувати свої івенти (наприклад SendToQueueEvent) навіть якщо проект не airslate